### PR TITLE
Rename AppDelegate to SystrayAppDelegate

### DIFF
--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -50,13 +50,13 @@ withParentMenuId: (int)theParentMenuId
 }
 @end
 
-@interface AppDelegate: NSObject <NSApplicationDelegate>
+@interface SystrayAppDelegate: NSObject <NSApplicationDelegate>
   - (void) add_or_update_menu_item:(MenuItem*) item;
   - (IBAction)menuHandler:(id)sender;
   @property (assign) IBOutlet NSWindow *window;
   @end
 
-  @implementation AppDelegate
+  @implementation SystrayAppDelegate
 {
   NSStatusItem *statusItem;
   NSMenu *menu;
@@ -226,7 +226,7 @@ NSMenuItem *find_menu_item(NSMenu *ourMenu, NSNumber *menuId) {
 @end
 
 void registerSystray(void) {
-  AppDelegate *delegate = [[AppDelegate alloc] init];
+  SystrayAppDelegate *delegate = [[SystrayAppDelegate alloc] init];
   [[NSApplication sharedApplication] setDelegate:delegate];
   // A workaround to avoid crashing on macOS versions before Catalina. Somehow
   // SIGSEGV would happen inside AppKit if [NSApp run] is called from a
@@ -244,7 +244,7 @@ int nativeLoop(void) {
 }
 
 void runInMainThread(SEL method, id object) {
-  [(AppDelegate*)[NSApp delegate]
+  [(SystrayAppDelegate*)[NSApp delegate]
     performSelectorOnMainThread:method
                      withObject:object
                   waitUntilDone: YES];


### PR DESCRIPTION
Renames AppDelegate to SystrayAppDelegate to attempt to resolve linking errors during Wails build on macOS