### PR TITLE
Add warning to README.md, change module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 systray is a cross-platform Go library to place an icon and menu in the notification area.
 
+### **This is a fork of [getlantern/systray](https://github.com/getlantern/systray) with no improvements made over upstream. This fork only contains a modification in `systray_darwin.m` to get around a linking issue in macOS during Wails build. Please use [getlantern/systray](https://github.com/getlantern/systray) in your project instead.**
+
 ## Features
 
 * Supported on Windows, macOS, and Linux

--- a/example/main.go
+++ b/example/main.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/getlantern/systray"
-	"github.com/getlantern/systray/example/icon"
+	"github.com/efeenesc/systray"
+	"github.com/efeenesc/systray/example/icon"
 	"github.com/skratchdot/open-golang/open"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
-module github.com/getlantern/systray
+module github.com/efeenesc/systray
 
 go 1.13
 
 require (
 	github.com/getlantern/golog v0.0.0-20190830074920-4ef2e798c2d7
+	github.com/getlantern/systray v1.2.2
 	github.com/lxn/walk v0.0.0-20210112085537-c389da54e794
-	github.com/lxn/win v0.0.0-20210218163916-a377121e959e // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/sys v0.1.0
-	gopkg.in/Knetic/govaluate.v3 v3.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55 h1:XYzSdCbkzOC0F
 github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55/go.mod h1:6mmzY2kW1TOOrVy+r41Za2MxXM+hhqTtY3oBKd2AgFA=
 github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f h1:wrYrQttPS8FHIRSlsrcuKazukx/xqO/PpLZzZXsF+EA=
 github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
+github.com/getlantern/systray v1.2.2 h1:dCEHtfmvkJG7HZ8lS/sLklTH4RKUcIsKrAD9sThoEBE=
+github.com/getlantern/systray v1.2.2/go.mod h1:pXFOI1wwqwYXEhLPm9ZGjS2u/vVELeIgNMY5HvhHhcE=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/lxn/walk v0.0.0-20210112085537-c389da54e794 h1:NVRJ0Uy0SOFcXSKLsS65OmI1sgCCfiDUPj+cwnH7GZw=


### PR DESCRIPTION
Changes module name from getlantern/systray to efeenesc/systray in go.mod to attempt to fix import issues