### PR TITLE
Handle Windows left click

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 systray is a cross-platform Go library to place an icon and menu in the notification area.
 
-### **This is a fork of [getlantern/systray](https://github.com/getlantern/systray) with no improvements made over upstream. This fork only contains a modification in `systray_darwin.m` to get around a linking issue in macOS during Wails build. Please use [getlantern/systray](https://github.com/getlantern/systray) in your project instead.**
+### **This is a fork of [getlantern/systray](https://github.com/getlantern/systray). This fork only contains:**
+- A variable name change in `systray_darwin.m` to get around a linking issue in macOS during Wails build.
+- A modification to handle icon left-click on Windows.
+
+Please use [getlantern/systray](https://github.com/getlantern/systray) or [energye/systray](https://github.com/energye/systray) (another fork of getlantern/systray that handles left-click on Windows, with a variety of other improvements) in your project instead.
 
 ## Features
 

--- a/systray.go
+++ b/systray.go
@@ -111,6 +111,12 @@ func Quit() {
 	quitOnce.Do(quit)
 }
 
+// AddIconClickAction triggers the passed callback when the icon is clicked.
+// This is only supported on Windows.
+func AddIconClickAction(callback func()) {
+	assignIconClickCallback(callback)
+}
+
 // AddMenuItem adds a menu item with the designated title and tooltip.
 // It can be safely invoked from different goroutines.
 // Created menu items are checkable on Windows and OSX by default. For Linux you have to use AddMenuItemCheckbox

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -42,3 +42,7 @@ func (item *MenuItem) SetTemplateIcon(templateIconBytes []byte, regularIconBytes
 func SetRemovalAllowed(allowed bool) {
 	C.setRemovalAllowed((C.bool)(allowed))
 }
+
+// Windows-only feature
+func assignIconClickCallback(callback func()) {
+}

--- a/systray_linux.go
+++ b/systray_linux.go
@@ -24,3 +24,7 @@ func (item *MenuItem) SetIcon(iconBytes []byte) {
 // .ico/.jpg/.png for other platforms.
 func (item *MenuItem) SetTemplateIcon(templateIconBytes []byte, regularIconBytes []byte) {
 }
+
+// Windows-only feature
+func assignIconClickCallback(callback func()) {
+}


### PR DESCRIPTION
Adds support for handling icon left-clicks on Windows with a new function; adds blank function declarations for Linux and Darwin